### PR TITLE
Linkedin x-ray search tap - views meta

### DIFF
--- a/data/taps/google/actor-output-fields.json
+++ b/data/taps/google/actor-output-fields.json
@@ -1,11 +1,11 @@
 {
     "actor_output_fields" : "searchQuery, url, hasNextPage, serpProviderCode, resultsTotal, relatedQueries, paidResults, paidProducts, organicResults, peopleAlsoAsk, customData",
     "actor_output_views": {
-        "overview": {
-            "title": "Overview"
-        },
         "organic_results": {
             "title": "Organic Results"
+        },
+        "overview": {
+            "title": "Overview"
         },
         "paid_results": {
             "title": "Paid Results (if any)"

--- a/data/taps/linkedin_xray/actor-output-fields.json
+++ b/data/taps/linkedin_xray/actor-output-fields.json
@@ -1,8 +1,14 @@
 {
     "actor_output_fields" : "searchQuery, url, hasNextPage, serpProviderCode, resultsTotal, relatedQueries, paidResults, paidProducts, organicResults, peopleAlsoAsk, customData",
     "actor_output_views": {
+        "organic_results": {
+            "title": "Organic Results"
+        },
         "overview": {
             "title": "Overview"
+        },
+        "paid_results": {
+            "title": "Paid Results (if any)"
         }
     }
 }


### PR DESCRIPTION
- Used the same "views" meta field as the "google search" tap as they both use the same Apify actor - google search.
- changed the order of views as "organic results" returns better descriptive result